### PR TITLE
Разные интерфейсы у блоков с одним вложенным элементом и несколькими

### DIFF
--- a/nokogiri.php
+++ b/nokogiri.php
@@ -202,12 +202,8 @@ class nokogiri implements IteratorAggregate{
 			}
 		}
 		if ($node->hasChildNodes()){
-			if ($node->childNodes->length == 1){
-				$array[$node->firstChild->nodeName] = $this->toArray($node->firstChild);
-			}else{
-				foreach ($node->childNodes as $childNode){
-					$array[$childNode->nodeName][] = $this->toArray($childNode);
-				}
+			foreach ($node->childNodes as $childNode){
+				$array[$childNode->nodeName][] = $this->toArray($childNode);
 			}
 		}
 		if ($xnode === null){


### PR DESCRIPTION
Если нужно распарсить несколько однотипных блоков, которые содержат в себе элементы, могла возникнуть ситуация когда у данных не одинаковый интерфейс.

$n['table'][0]['tbody'][0]['tr'][0]['td']
$n['table'][0]['tbody'][0]['tr'][1]['td']
$n['table'][0]['tbody'][0]['tr']['td']
