### PR TITLE
Fixed nokogiri::fromDom($dom)

### DIFF
--- a/nokogiri.php
+++ b/nokogiri.php
@@ -244,11 +244,7 @@ class nokogiri implements IteratorAggregate{
 		}
 		return $array;
 	}
-    public function toText($arr, $glue = " "){
-        return trim($this->_get_text_recursive($arr, $glue));
-    }
-    
-    private function _get_text_recursive($arr, $glue = "\n"){
+    private function _get_text_recursive($arr, $glue = " "){
         if(isset($arr['#text'])) $str =  $glue.implode($glue, $arr['#text']);
         // elseif(isset($arr['value'])) $str =  $glue.implode($glue, $arr['value']);
         else $str = '';
@@ -257,15 +253,21 @@ class nokogiri implements IteratorAggregate{
         }
         return $str;
     }
-    
-    // Возвращает одномерный массив toText() каждого элемента в наборе
-    // Первый параметр может быть массивом селекторов или строкой. Во втором случае принимаем его за $glue
-    public function toTextArray($param = null, $glue = " "){
-        if (is_array($param)) $selectors = $param;
-        else $selectors = array(); 
+   
+    /**
+    * Первый параметр может быть массивом селекторов или строкой. Во втором случае принимаем его за $glue
+    * Возвращает одно- или двумерный массив toText() каждого элемента в наборе
+    * Если передан массив селекторов, то вернёт двумерный массив с результатами субвыборки
+    */
+    public function toTextArray($param = null, $glue = null){
+        if (is_array($param)){
+            $selectors = $param;
+        } else {
+            $selectors = array(); 
+        }
         
-        if (is_string($param) && !$glue) $glue = $param;
-        $arr = $this->toArray();
+        if (is_string($param) && !$glue) {   $glue = $param;    }
+        if (is_null($glue))              {   $glue = ' ';       }
         
         $array = array();
         
@@ -273,7 +275,7 @@ class nokogiri implements IteratorAggregate{
             if ($selectors){
                 foreach ($this->_dom as $node){
                     foreach ($selectors as $key => $selector){
-                        $tmp[$key] = $this->toText( self::fromDom($node)->get($selector)->toArray() );
+                        $tmp[$key] = trim($this->_get_text_recursive( self::fromDom($node)->get($selector)->toArray() ));
                     }
                     $array[] = $tmp;
                 }


### PR DESCRIPTION
При передаче DOMElement в nokogiri::fromDom(), а затем
 вызове $nokogiri->get(' ... ') падает, т.к. метод getDom() возвращает пустоту.
```Fatal error:  Uncaught exception 'DOMException' with message 'DOMXPath::__construct() expects parameter 1 to be DOMDocument, null given' in nokogiri.php:132
Stack trace:
#0 nokogiri.php(132): DOMXPath->__construct(NULL)
#1 nokogiri.php(198): nokogiri->getXpath()
#2 nokogiri.php(109): nokogiri->getElements('//*[contains(co...')
#3 index.php(70): nokogiri->get('.some_class...')
#4 {main}  thrown in nokogiri.php on line 132```
